### PR TITLE
Add Docker Compose profiles and comprehensive documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,8 @@ Follow these steps to get your Bitrix environment up and running:
     ```
     This project primarily uses pre-built Docker images from a container registry (like GitHub Container Registry - GHCR). Therefore, running `docker-compose build` or adding the `--build` flag is generally not necessary for standard usage. Docker Compose will automatically pull the specified images if they are not present locally. You would typically only need to use `--build` if you have made custom modifications to the Dockerfiles and need to rebuild the images locally.
 
+    To manage optional services, refer to the "[Managing Optional Services with Profiles](#managing-optional-services-with-profiles)" section.
+
 ## How to make use of it
 
 You couldn't use it as-is without alterations. However, I tried to make everything as generic as possible to make adoption for another project easy. To use it, read through [docker-compose.yml](docker-compose.yml)
@@ -250,6 +252,41 @@ Site files in directories `web/prod` and `web/dev`.
 - `private/mysqld` directory will contain MySQL unix socket for connections without network
 
 - `private/msmtprc` is a file with [msmtp configuration](https://wiki.archlinux.org/index.php/Msmtp)
+
+## Managing Optional Services with Profiles
+
+This project uses Docker Compose profiles to manage optional services. This allows you to run only the services you need, saving resources. The core services (`nginx`, `php`, `mysql`, `memcached`, `memcached-sessions`) will always start.
+
+Here are the available profiles and the services they enable:
+
+*   **`certs`**: Enables the `certbot` service (using DNSroboCert technology via the `adferrand/dnsrobocert` image) for managing SSL certificates.
+*   **`cron`**: Enables `php-cron` for running scheduled tasks.
+*   **`monitoring`**: Enables `zabbix-agent` for Zabbix monitoring.
+*   **`dbadmin`**: Enables `adminer` for database administration.
+*   **`hooks`**: Enables `updater` for handling webhooks.
+*   **`ftp`**: Enables `ftp` for FTP access.
+
+**Examples:**
+
+*   To run only the core services:
+    ```bash
+    docker-compose up -d
+    ```
+
+*   To run core services plus `php-cron` and `adminer`:
+    ```bash
+    docker-compose --profile cron --profile dbadmin up -d
+    ```
+    Alternatively, you can list multiple profiles in a single `--profile` flag:
+    ```bash
+    docker-compose --profile cron --profile dbadmin up -d
+    ```
+
+*   To run all services, including all defined profiles:
+    ```bash
+    docker-compose --profile "*" up -d
+    ```
+    As mentioned in "Getting Started," this project uses pre-built images. If you've made custom changes to Dockerfiles or need to ensure you have the absolute latest build not yet reflected in the pre-built images, you can add the `--build` flag (e.g., `docker-compose --profile "*" up --build -d`).
 
 ## Advanced Usage
 

--- a/Readme.md
+++ b/Readme.md
@@ -255,12 +255,13 @@ Site files in directories `web/prod` and `web/dev`.
 
 ## Managing Optional Services with Profiles
 
-This project uses Docker Compose profiles to manage optional services. This allows you to run only the services you need, saving resources. The core services (`nginx`, `php`, `mysql`, `memcached`, `memcached-sessions`) will always start.
+This project uses Docker Compose profiles to manage optional services. This allows you to run only the services you need, saving resources. The core services (`nginx`, `php`, `php-cron`, `mysql`, `memcached`, `memcached-sessions`) will always start.
+
+**⚠️ Breaking Change Notice**: If you were previously running services like `adminer`, `zabbix-agent`, `updater`, or `ftp`, they will no longer start automatically with `docker-compose up -d`. You must now explicitly enable them using profiles (see examples below) or set the `COMPOSE_PROFILES` environment variable.
 
 Here are the available profiles and the services they enable:
 
 *   **`certs`**: Enables the `certbot` service (using DNSroboCert technology via the `adferrand/dnsrobocert` image) for managing SSL certificates.
-*   **`cron`**: Enables `php-cron` for running scheduled tasks.
 *   **`monitoring`**: Enables `zabbix-agent` for Zabbix monitoring.
 *   **`dbadmin`**: Enables `adminer` for database administration.
 *   **`hooks`**: Enables `updater` for handling webhooks.
@@ -273,13 +274,19 @@ Here are the available profiles and the services they enable:
     docker-compose up -d
     ```
 
-*   To run core services plus `php-cron` and `adminer`:
+*   To run core services plus `adminer` and `ftp`:
     ```bash
-    docker-compose --profile cron --profile dbadmin up -d
+    docker-compose --profile dbadmin --profile ftp up -d
     ```
-    Alternatively, you can list multiple profiles in a single `--profile` flag:
+
+*   Alternatively, you can set profiles using the `COMPOSE_PROFILES` environment variable:
     ```bash
-    docker-compose --profile cron --profile dbadmin up -d
+    COMPOSE_PROFILES=dbadmin,ftp docker-compose up -d
+    ```
+    Or export it for the session:
+    ```bash
+    export COMPOSE_PROFILES=dbadmin,ftp
+    docker-compose up -d
     ```
 
 *   To run all services, including all defined profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 # Yandex.Cloud external IP with DDoS Protection enabled has a requirement of MTU of 1450
 # according to https://github.com/moby/moby/issues/22297#issuecomment-242934050 that's the only way to set it inside docker-compose
 networks:
@@ -13,6 +11,8 @@ services:
     image: adferrand/dnsrobocert
     hostname: certbot
     container_name: certbot
+    profiles:
+      - certs
     volumes:
       - ./private/letsencrypt:/etc/letsencrypt
       # needed for nginx container autorestart, https://dnsrobocert.readthedocs.io/en/latest/configuration_reference.html#autorestart
@@ -122,6 +122,8 @@ services:
     image: ghcr.io/paskal/bitrix-php:8.2
     hostname: php-cron
     container_name: php-cron
+    profiles:
+      - cron
     depends_on:
       - memcached
       - memcached-sessions
@@ -199,6 +201,8 @@ services:
     image: adminer
     hostname: adminer
     container_name: adminer
+    profiles:
+      - dbadmin
     expose:
       - "8080"
     environment:
@@ -223,6 +227,8 @@ services:
     build: ./config/zabbix
     image: ghcr.io/paskal/zabbix-agent2:latest
     container_name: zabbix-agent
+    profiles:
+      - monitoring
     privileged: true
     # MYSQL_USER, MYSQL_PASSWORD
     # ZBX_HOSTNAME, ZBX_SERVER_HOST
@@ -258,6 +264,8 @@ services:
     image: ghcr.io/umputun/updater:master
     container_name: updater
     hostname: updater
+    profiles:
+      - hooks
     restart: always
     logging:
       driver: json-file
@@ -278,25 +286,26 @@ services:
 
   # FTP access
 
-#  ftp:
-#    image: stilliard/pure-ftpd
-#    container_name: ftp
-#    # FTP_USER_NAME, FTP_USER_PASS
-#    env_file: private/environment/ftp.env
-#    ports:
-#      - "21:21"
-#      - "30000-30009:30000-30009"
-#    volumes:
-#      - ./web/dev:/home/web
-#    environment:
-#      PUBLICHOST: favor-group.ru
-#      FTP_USER_HOME: /home/web
-#      FTP_PASSIVE_PORTS: 30000:30009
-#
-#    logging:
-#      driver: json-file
-#      options:
-#        max-size: "10m"
-#        max-file: "5"
-#
-#    restart: unless-stopped
+  ftp:
+    image: stilliard/pure-ftpd
+    container_name: ftp
+    # FTP_USER_NAME, FTP_USER_PASS
+    env_file: private/environment/ftp.env
+    ports:
+      - "21:21"
+      - "30000-30009:30000-30009"
+    volumes:
+      - ./web/dev:/home/web
+    environment:
+      PUBLICHOST: favor-group.ru
+      FTP_USER_HOME: /home/web
+      FTP_PASSIVE_PORTS: 30000:30009
+    profiles:
+      - ftp
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,8 +122,6 @@ services:
     image: ghcr.io/paskal/bitrix-php:8.2
     hostname: php-cron
     container_name: php-cron
-    profiles:
-      - cron
     depends_on:
       - memcached
       - memcached-sessions


### PR DESCRIPTION
## Summary
- Add Docker Compose profiles for optional services (certs, monitoring, dbadmin, hooks, ftp)
- Make php-cron a core service that always starts (essential for Bitrix)
- Remove deprecated version field from docker-compose.yml
- Enable FTP service with profile configuration
- Add comprehensive Getting Started guide and service management documentation
- Document COMPOSE_PROFILES environment variable usage with examples
- Add breaking change notice for users of optional services

## Key Changes
- **Profiles support**: Optional services now use profiles for selective deployment
- **Core services**: nginx, php, php-cron, mysql, memcached, memcached-sessions always start
- **Breaking change mitigation**: Clear documentation and examples for affected users
- **Enhanced documentation**: Step-by-step guides and profile usage examples